### PR TITLE
Change order of env sources in getEnv()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function dynamicConfig(basePath, fileName) {
 }
 
 dynamicConfig.getEnv = function() {
-    return process.env.env || argv.env || argv.ENV || dynamicConfig.options.defaultEnv;
+    return argv.env || argv.ENV || process.env.env || dynamicConfig.options.defaultEnv;
 };
 
 dynamicConfig.getFilePath = function(basePath, env, fileName) {


### PR DESCRIPTION
In my opinion the arguments to the process should take precedence over any global environment variables. If you agree, you can merge my pull request :smile: 
