### PR TITLE
Add process.env.ENV to getEnv() method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function dynamicConfig(basePath, fileName) {
 }
 
 dynamicConfig.getEnv = function() {
-    return argv.env || argv.ENV || process.env.env || dynamicConfig.options.defaultEnv;
+    return argv.env || argv.ENV || process.env.env || process.env.ENV || dynamicConfig.options.defaultEnv;
 };
 
 dynamicConfig.getFilePath = function(basePath, env, fileName) {


### PR DESCRIPTION
Good evening :wave: 

since dynamic-config is considering `argv.env` and `argv.ENV` it should probably also consider `process.env.env` and `process.env.ENV`. The latter is missing at the moment and is added with this PR.

Best regards,
Benjamin