### PR TITLE
Fix argument type check in plugins

### DIFF
--- a/plugins/extend/argv/index.js
+++ b/plugins/extend/argv/index.js
@@ -22,7 +22,7 @@ function argvPlugin(dynamicConfig, options) {
         console.warn("Passing options as separate arguments to a dynamic-config plugin is deprecated. Use an options object instead. This will be removed in the next major version.");
         separator = arguments[1];
         whitelist = arguments[2];
-    } else if (arguments.length > 1) {
+    } else if (options && typeof options === "object") {
         separator = options.separator;
         whitelist = options.whitelist;
     }

--- a/plugins/extend/env/index.js
+++ b/plugins/extend/env/index.js
@@ -21,7 +21,7 @@ function envPlugin(dynamicConfig, options) {
         console.warn("Passing options as separate arguments to a dynamic-config plugin is deprecated. Use an options object instead. This will be removed in the next major version.");
         separator = arguments[1];
         whitelist = arguments[2];
-    } else if (arguments.length > 1) {
+    } else if (options && typeof options === "object") {
         separator = options.separator;
         whitelist = options.whitelist;
     }

--- a/plugins/extend/file/index.js
+++ b/plugins/extend/file/index.js
@@ -19,8 +19,8 @@ function filePlugin(dynamicConfig, options) {
 
     if (typeof options === "string") {
         console.warn("Passing options as separate arguments to a dynamic-config plugin is deprecated. Use an options object instead. This will be removed in the next major version.");
-        suffix = options;
-    } else if (arguments.length > 1) {
+        suffix = arguments[1];
+    } else if (options && typeof options === "object") {
         suffix = options.suffix;
     }
 


### PR DESCRIPTION
Currently the if body does not match the check for it. It is assumed that the options argument is an object, but it is only checked for existence. I would change the check to include the type, but ofc that's up to you 😄 