### PR TITLE
remove try/catch block to give better error messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,20 +31,7 @@ dynamicConfig.getFilePath = function (basePath, env, fileName) {
 };
 
 dynamicConfig.loadConfig = function (filePath) {
-    var config;
-
-    try {
-        config = require(filePath);
-    } catch (err) {
-        // handle only not found errors, throw the rest
-        if (err.code === "MODULE_NOT_FOUND") {
-            throw new Error("Config not found at '" + filePath + "'");
-        }
-
-        throw err;
-    }
-
-    return config;
+    return require(filePath);
 };
 
 dynamicConfig.options = {


### PR DESCRIPTION
The try/catch blocks kills the stack trace required to find any errors in your webpack config, e.g. missing modules.